### PR TITLE
Add table of contents to bottom of intro page

### DIFF
--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -9,7 +9,7 @@
 
     <div
       class="table-of-content"
-      :class="{ 'hidden': isActive($route, '/') }"
+      :class="hideTableOfContent"
     >
       <h3 class="title">Table of Content</h3>
       <Sidebar class="intro-sidebar" :items="sidebarItems" />
@@ -37,14 +37,18 @@ import PageEdit from "@parent-theme/components/PageEdit.vue";
 import PageNav from "@parent-theme/components/PageNav.vue";
 import Sidebar from "@parent-theme/components/Sidebar.vue";
 
-console.log('--- active', isActive(this.$route, '/'), this.$route);
-
 export default {
   name: 'Page',
 
   components: { PageEdit, PageNav, Sidebar },
 
   props: ["sidebarItems"],
+
+  computed: {
+    hideTableOfContent() {
+      return { 'hidden': !isActive(this.$route, '/') }; 
+    }
+  },
 };
 </script>
 

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -9,7 +9,7 @@
 
     <div class="table-of-content" :class="{ 'hidden': hideTableOfContents }">
       <h3 class="title">Table of Content</h3>
-      <Sidebar class="intro-sidebar" :items="sidebarItems"></Sidebar>
+      <Sidebar class="intro-sidebar" :items="sidebarItems" />
     </div>
 
     <slot name="bottom" />
@@ -42,6 +42,7 @@ export default {
 
   computed: {
     hideTableOfContents() {
+      console.log('--- route name check', this.$route.name === 'v-d967ece0');
       return this.$route.name === 'v-d967ece0' ? false : true; 
     }
   },
@@ -67,7 +68,7 @@ $font-xs = 0.625rem /* 10px */
   .table-of-content
     display none
 
-.intro-sidebar
+.intro-sidebar.sidebar
   background-color #fff
   background-color transparent
   border-right none
@@ -91,7 +92,7 @@ $font-xs = 0.625rem /* 10px */
 
 
 @media (max-width: $MQMobile)
-  .intro-sidebar
+  .intro-sidebar.sidebar
     transform initial
 
 .footer

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -7,6 +7,11 @@
 
     <PageNav v-bind="{ sidebarItems }" />
 
+    <div class="table-of-content" :class="{ 'hidden': hideTableOfContents }">
+      <h3 class="title">Table of Content</h3>
+      <Sidebar class="intro-sidebar" :items="sidebarItems"></Sidebar>
+    </div>
+
     <slot name="bottom" />
 
     <footer class="footer">
@@ -26,10 +31,20 @@
 <script>
 import PageEdit from "@parent-theme/components/PageEdit.vue";
 import PageNav from "@parent-theme/components/PageNav.vue";
+import Sidebar from "@parent-theme/components/Sidebar.vue";
 
 export default {
-  components: { PageEdit, PageNav },
-  props: ["sidebarItems"]
+  name: 'Page',
+
+  components: { PageEdit, PageNav, Sidebar },
+
+  props: ["sidebarItems"],
+
+  computed: {
+    hideTableOfContents() {
+      return this.$route.path === '/' ? false : true; 
+    }
+  },
 };
 </script>
 
@@ -38,6 +53,46 @@ $light-3 = #F6F6F6
 $dark-3 = #3D3D4B
 $dark-5 = #92929F
 $font-xs = 0.625rem /* 10px */
+
+.table-of-content
+  &.hidden
+    display none
+
+  .title
+    padding-top 2.875rem
+    margin 0 2rem 1rem
+    border-top 1px solid $borderColor
+
+@media (min-width: $MQMobile)
+  .table-of-content
+    display none
+
+.intro-sidebar
+  background-color #fff
+  background-color transparent
+  border-right none
+  bottom initial
+  box-sizing border-box
+  font-size 16px
+  left initial
+  margin 0
+  overflow-y auto
+  padding-top 0
+  position static
+  top initial
+  width initial
+  z-index 1
+
+  .nav-links
+    display none
+
+  .sidebar-link
+    padding 0.35rem 2rem 0.35rem 1.75rem
+
+
+@media (max-width: $MQMobile)
+  .intro-sidebar
+    transform initial
 
 .footer
   background-color $light-3

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -42,7 +42,7 @@ export default {
 
   computed: {
     hideTableOfContents() {
-      return this.$route.path === '/' ? false : true; 
+      return this.$route.name === 'v-d967ece0' ? false : true; 
     }
   },
 };

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -11,7 +11,7 @@
       class="table-of-content"
       :class="hideTableOfContent"
     >
-      <h3 class="title">Table of Content</h3>
+      <h3 class="title">Table of contents</h3>
       <Sidebar class="intro-sidebar" :items="sidebarItems" />
     </div>
 

--- a/docs/.vuepress/theme/components/Page.vue
+++ b/docs/.vuepress/theme/components/Page.vue
@@ -7,7 +7,10 @@
 
     <PageNav v-bind="{ sidebarItems }" />
 
-    <div class="table-of-content" :class="{ 'hidden': hideTableOfContents }">
+    <div
+      class="table-of-content"
+      :class="{ 'hidden': isActive($route, '/') }"
+    >
       <h3 class="title">Table of Content</h3>
       <Sidebar class="intro-sidebar" :items="sidebarItems" />
     </div>
@@ -29,9 +32,12 @@
 </template>
 
 <script>
+import { isActive } from '@parent-theme/util';
 import PageEdit from "@parent-theme/components/PageEdit.vue";
 import PageNav from "@parent-theme/components/PageNav.vue";
 import Sidebar from "@parent-theme/components/Sidebar.vue";
+
+console.log('--- active', isActive(this.$route, '/'), this.$route);
 
 export default {
   name: 'Page',
@@ -39,13 +45,6 @@ export default {
   components: { PageEdit, PageNav, Sidebar },
 
   props: ["sidebarItems"],
-
-  computed: {
-    hideTableOfContents() {
-      console.log('--- route name check', this.$route.name === 'v-d967ece0');
-      return this.$route.name === 'v-d967ece0' ? false : true; 
-    }
-  },
 };
 </script>
 


### PR DESCRIPTION
# What does this pull request do?

1. Add table of contents (using the already made `<Sidebar>` component) to the bottom of the introduction page for smaller screen sizes.
    * The table of contents only shows on small screen sizes.
    * The table of contents only shows on the introduction page (via the path `/`).

This will close #7.

![table-of-contents](https://user-images.githubusercontent.com/9101728/68890828-544f9300-06e5-11ea-8be3-1b0774a180b7.gif)
